### PR TITLE
Add corresponding skills for create-* commands

### DIFF
--- a/plugins/dg/skills/create-project/SKILL.md
+++ b/plugins/dg/skills/create-project/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: dg:create-project
+description: Create a new Dagster project with recommended structure. Use when user wants to initialize, scaffold, or create a new Dagster project.
+---
+
+# Create Dagster Project Skill
+
+This skill helps users create new Dagster projects through natural language requests.
+
+## When to Use This Skill
+
+Auto-invoke when users say:
+- "create a dagster project"
+- "initialize a dagster project"
+- "scaffold a new dagster project"
+- "start a new dagster project"
+- "make a dagster project"
+- "set up a dagster project"
+- "create a new dagster project"
+
+## How It Works
+
+When this skill is invoked:
+
+1. **Extract the project name** from the user's request (if provided)
+2. **Invoke the underlying command**: `/dg:create-project <name>`
+3. **Handle missing parameters**:
+   - If user specified a name: use it directly
+   - If user said "here" or "in current directory": use `.`
+   - If no name provided: ask the user for the project name
+
+## Example Flows
+
+**User provides a name:**
+```
+User: "Create a dagster project called my-pipeline"
+→ Invoke: /dg:create-project my-pipeline
+```
+
+**User doesn't provide a name:**
+```
+User: "I want to create a new dagster project"
+→ Ask: "What would you like to name your Dagster project?"
+→ Wait for user response
+→ Invoke: /dg:create-project <user-provided-name>
+```
+
+**User wants to create in current directory:**
+```
+User: "Create a dagster project here"
+→ Invoke: /dg:create-project .
+```
+
+**User provides a path:**
+```
+User: "Create a dagster project at ./my-projects/pipeline"
+→ Invoke: /dg:create-project ./my-projects/pipeline
+```
+
+## Implementation Notes
+
+- This skill is a thin wrapper that delegates to the `/dg:create-project` command
+- The command file at `commands/create-project.md` contains the actual execution logic
+- Explicit slash command invocation still works: `/dg:create-project <name>`
+- Both natural language and explicit invocation are supported
+
+## Related Commands
+
+After creating a project, users may want to:
+- Use `/dg:prototype <requirements>` to build their first assets
+- Use `dg dev` to start the Dagster UI
+- Navigate to the project directory if they created it with a name

--- a/plugins/dg/skills/create-workspace/SKILL.md
+++ b/plugins/dg/skills/create-workspace/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: dg:create-workspace
+description: Create a new Dagster workspace for managing multiple projects. Use when user wants to initialize a workspace, manage multiple Dagster projects together, or set up a multi-project environment.
+---
+
+# Create Dagster Workspace Skill
+
+This skill helps users create Dagster workspaces through natural language requests.
+
+## When to Use This Skill
+
+Auto-invoke when users say:
+- "create a dagster workspace"
+- "initialize a dagster workspace"
+- "set up a multi-project dagster environment"
+- "create a workspace for multiple dagster projects"
+- "make a dagster workspace"
+- "start a new dagster workspace"
+- "scaffold a dagster workspace"
+
+## How It Works
+
+When this skill is invoked:
+
+1. **Extract the workspace name** from the user's request (if provided)
+2. **Invoke the underlying command**: `/dg:create-workspace <name>`
+3. **Handle missing parameters**:
+   - If user specified a name: use it directly
+   - If user said "here" or "in current directory": use `.`
+   - If no name provided: ask the user for the workspace name
+
+## Example Flows
+
+**User provides a name:**
+```
+User: "Create a dagster workspace called my-org"
+→ Invoke: /dg:create-workspace my-org
+```
+
+**User doesn't provide a name:**
+```
+User: "I want to set up a workspace for multiple dagster projects"
+→ Ask: "What would you like to name your Dagster workspace?"
+→ Wait for user response
+→ Invoke: /dg:create-workspace <user-provided-name>
+```
+
+**User wants to create in current directory:**
+```
+User: "Create a dagster workspace here"
+→ Invoke: /dg:create-workspace .
+```
+
+**User provides a path:**
+```
+User: "Create a dagster workspace at ./workspaces/analytics"
+→ Invoke: /dg:create-workspace ./workspaces/analytics
+```
+
+## Implementation Notes
+
+- This skill is a thin wrapper that delegates to the `/dg:create-workspace` command
+- The command file at `commands/create-workspace.md` contains the actual execution logic
+- Explicit slash command invocation still works: `/dg:create-workspace <name>`
+- Both natural language and explicit invocation are supported
+
+## Related Commands
+
+After creating a workspace, users may want to:
+- Use `/dg:create-project <name>` to add projects to the workspace
+- Use `dg dev` to start the Dagster UI for the workspace
+- Navigate to the workspace directory if they created it with a name

--- a/plugins/dg/skills/prototype/SKILL.md
+++ b/plugins/dg/skills/prototype/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: dg:prototype
+description: Build production-ready Dagster implementations with best practices, testing, and validation. Use when user wants to prototype, build, implement, or create Dagster assets, pipelines, workflows, or data integrations.
+---
+
+# Prototype Dagster Implementation Skill
+
+This skill helps users build production-ready Dagster implementations through natural language requests.
+
+## When to Use This Skill
+
+Auto-invoke when users say:
+- "prototype a dagster pipeline"
+- "build a dagster workflow"
+- "implement a dagster asset"
+- "create a data pipeline in dagster"
+- "I want to build [X] using dagster"
+- "help me implement [Y] in dagster"
+- "create a dagster implementation for [Z]"
+- "build assets for [X]"
+- "implement [X] with dagster"
+
+## How It Works
+
+When this skill is invoked:
+
+1. **Extract requirements** from the user's request (what they want to build)
+2. **Identify any specific integrations** mentioned (e.g., Snowflake, dbt, APIs)
+3. **Invoke the underlying command**: `/dg:prototype <requirements>`
+4. **Handle vague requests**:
+   - If requirements are too vague, ask clarifying questions
+   - Extract data sources, transformations, destinations, and constraints
+
+## Example Flows
+
+**Clear requirements:**
+```
+User: "I want to build a data pipeline that loads data from Snowflake and transforms it with dbt"
+→ Invoke: /dg:prototype Build a pipeline that: 1) loads data from Snowflake using dagster-snowflake, 2) transforms with dbt using dagster-dbt
+```
+
+**General request:**
+```
+User: "Prototype a dagster workflow for processing customer data"
+→ Invoke: /dg:prototype Process customer data with appropriate transformations and validation
+```
+
+**Asset creation:**
+```
+User: "Create a dagster asset that fetches data from an API"
+→ Invoke: /dg:prototype Create an asset that fetches data from an external API with error handling and retries
+```
+
+**Complex integration:**
+```
+User: "Build a pipeline that ingests from PostgreSQL, transforms with Spark, and loads to BigQuery"
+→ Invoke: /dg:prototype Build a pipeline that: 1) ingests from PostgreSQL, 2) transforms with PySpark, 3) loads to BigQuery
+```
+
+**Vague request - needs clarification:**
+```
+User: "Help me build a data pipeline"
+→ Ask: "What would you like your pipeline to do? Please describe:
+  - Data source(s) (APIs, databases, files, etc.)
+  - Transformations needed
+  - Output destination(s)
+  - Any specific integrations or constraints"
+→ Wait for user response
+→ Invoke: /dg:prototype <detailed-requirements>
+```
+
+## Implementation Notes
+
+- This skill is a thin wrapper that delegates to the `/dg:prototype` command
+- The command file at `commands/prototype.md` contains the actual execution logic
+- The prototype command automatically leverages:
+  - `dagster-conventions` skill for best practices
+  - `dagster-integrations` skill for discovering appropriate integrations
+- Explicit slash command invocation still works: `/dg:prototype <requirements>`
+- Both natural language and explicit invocation are supported
+
+## Integration with Other Skills
+
+The `/dg:prototype` command works seamlessly with:
+
+**dagster-conventions:**
+- Provides best practices for asset design
+- Guides testing patterns
+- Ensures proper resource configuration
+- Recommends project structure
+
+**dagster-integrations:**
+- Suggests appropriate integrations for use cases
+- Provides integration-specific guidance
+- Helps choose between similar tools (e.g., dbt vs Sling)
+
+You don't need to manually invoke these skills - the prototype command handles it automatically.
+
+## What Gets Built
+
+When you invoke this skill, the prototype command will:
+1. Analyze requirements and suggest appropriate patterns
+2. Create production-ready assets with proper dependencies
+3. Set up resources and configuration
+4. Include comprehensive tests
+5. Add documentation and metadata
+6. Follow Dagster best practices throughout
+
+## Related Commands
+
+Before prototyping, users may need to:
+- Use `/dg:create-project <name>` to set up a new project first
+- Navigate to their existing Dagster project directory
+
+After prototyping, users can:
+- Run `dg dev` to see their implementation in the Dagster UI
+- Use `pytest` to run the generated tests
+- Extend the implementation with additional assets


### PR DESCRIPTION
## Summary & Motivation

Created three skill wrappers to enable natural language invocation:

1. plugins/dg/skills/create-project/SKILL.md
    - Auto-invokes when users say "create a dagster project", "make a dagster project", etc.
    - Delegates to /dg:create-project command
2. plugins/dg/skills/create-workspace/SKILL.md
   - Auto-invokes when users say "create a dagster workspace", "set up a multi-project environment", etc.
    - Delegates to /dg:create-workspace command
3. plugins/dg/skills/prototype/SKILL.md
    - Auto-invokes when users say "build a dagster pipeline", "implement a dagster asset", etc.
    - Delegates to /dg:prototype command

Updated documentation in README.md to show both invocation methods:
- Natural language examples for each build command
- Clarified that debugging commands (logs, troubleshoot) remain explicit-only

How It Works

Natural Language: When a user says "create a dagster project called my-pipeline", Claude will:
1. Recognize the intent matches the skill description
2. Auto-invoke the skill
3. Extract parameters (name: "my-pipeline")
4. Execute /dg:create-project my-pipeline

Explicit Commands: Users can still type /dg:create-project my-pipeline directly - both methods work!

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
