### PR TITLE
Update conventions to reocmmend remote dbt project configuration

### DIFF
--- a/plugins/dagster-conventions/skills/dagster-conventions/references/project-structure.md
+++ b/plugins/dagster-conventions/skills/dagster-conventions/references/project-structure.md
@@ -419,16 +419,49 @@ streams:
 
 ### dbt Component Example
 
-```yaml
-# defs/transform_dbt/defs.yaml
-component: dagster_dbt.DbtProjectComponent
+**Remote Git Repository (Recommended)**:
 
-params:
-  project_dir: ../../dbt_project
+```yaml
+# defs/transform/defs.yaml
+type: dagster_dbt.DbtProjectComponent
+
+attributes:
+  project:
+    repo_url: https://github.com/dagster-io/jaffle-platform.git
+    repo_relative_path: jdbt
+  dbt:
+    target: dev
+```
+
+The remote configuration manages the dbt project as component state without requiring you to clone the repository locally.
+
+**For private repositories**, add token authentication:
+
+```yaml
+attributes:
+  project:
+    repo_url: https://github.com/your-org/dbt-project.git
+    repo_relative_path: dbt
+    token: '{{ env.GIT_TOKEN }}'
+  dbt:
+    target: dev
+```
+
+**Local Project (Alternative for Development)**:
+
+```yaml
+# defs/transform/defs.yaml
+type: dagster_dbt.DbtProjectComponent
+
+attributes:
+  project:
+    project_dir: ../../dbt_project
   dbt:
     target: dev
     profiles_dir: ~/.dbt
 ```
+
+Use local configuration when actively developing dbt models or when the dbt project is colocated in your Dagster repository.
 
 ### Combining Components with Pythonic Assets
 

--- a/plugins/dagster-integrations/skills/integrations-index/references/etl.md
+++ b/plugins/dagster-integrations/skills/integrations-index/references/etl.md
@@ -15,11 +15,24 @@ Transform data using SQL models with automatic dependency management, incrementa
 - Test data quality with dbt tests
 - Document data lineage and schemas
 
-**Quick start:**
+**Quick start (Component-based - Recommended):**
+```yaml
+# defs/transform/defs.yaml
+type: dagster_dbt.DbtProjectComponent
+
+attributes:
+  project:
+    repo_url: https://github.com/dagster-io/jaffle-platform.git
+    repo_relative_path: jdbt
+  dbt:
+    target: dev
+```
+
+**Quick start (Pythonic):**
 ```python
 from dagster_dbt import DbtProject, dbt_assets
 
-# Scaffold a dbt project
+# For local projects
 my_project = DbtProject(project_dir="path/to/dbt/project")
 
 # Create assets from dbt models
@@ -38,10 +51,11 @@ defs = dg.Definitions(
 **Docs:** https://docs.dagster.io/integrations/libraries/dbt
 
 **Key features:**
-- Component-based scaffolding with `dagster-dbt project scaffold`
+- Component-based scaffolding with remote Git repositories
 - Automatic asset creation from dbt models
 - Incremental model support
 - dbt test integration
+- Support for both remote and local projects
 
 ---
 

--- a/plugins/dg/commands/prototype.md
+++ b/plugins/dg/commands/prototype.md
@@ -41,6 +41,7 @@ This command guides you through building production-ready Dagster code with:
 - Need declarative YAML configuration
 - Want reusability across projects
 - Building standardized data pipelines
+- **For dbt**: Use remote Git repository configuration to avoid cloning projects locally
 
 **Use Pythonic Assets when**:
 - Custom business logic required
@@ -71,6 +72,7 @@ This command guides you through building production-ready Dagster code with:
    - Set all required parameters
    - Reference environment variables appropriately
    - Configure component-specific settings
+   - **For dbt components**: Prefer `repo_url` + `repo_relative_path` over `project_dir`
 
 4. **Validate the component loads**:
    ```bash


### PR DESCRIPTION
## Summary & Motivation

1. project-structure.md (+39 lines)

- Replaced local project_dir example with remote Git repository configuration as the primary example
- Added jaffle-platform repository as the example
- Included private repository authentication guidance with {{ env.GIT_TOKEN }}
- Kept local configuration as an alternative for development
- Updated component: to type: and params: to attributes: for modern syntax

2. etl.md (+18 lines)

- Added "Component-based - Recommended" quick start section with remote configuration
- Relabeled Pythonic example as alternative approach
- Updated key features to mention "remote Git repositories" instead of generic scaffolding
- Added "Support for both remote and local projects" to features

3. SKILL.md (+42 lines)

- Expanded dbt Integration section with clear guidance on when to use each approach
- Added "Component-Based dbt (Recommended)" section with remote configuration
- Included private repository example with token authentication
- Reorganized Pythonic assets as secondary option with clear use cases
- Combined dbt Resource section into the Pythonic example

4. prototype.md (+2 lines)

- Added note about using remote Git repository configuration for dbt in "Use Components when" section
- Added guidance to prefer repo_url + repo_relative_path over project_dir in YAML configuration section

Key Improvements

All documentation now:
- Recommends remote configuration first while keeping local as an option
- Uses consistent examples (jaffle-platform repository)
- Includes authentication guidance for private repositories
- Clearly explains when to use each approach (component vs Pythonic, remote vs local)
- Uses modern syntax (type: and attributes: instead of component: and params:)

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
