### PR TITLE
[dg] update lauch command asset selection syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- **dg**: Fixed `dg launch` documentation to use comma-separated asset syntax
+  - Updated SKILL.md and launch.md to show correct syntax: `--assets asset1,asset2,asset3`
+  - Previous incorrect examples showed space-separated: `--assets asset1 asset2 asset3`
+  - Verified against actual CLI implementation in dagster repository
+  - Selection patterns (tags, groups, kinds) preserved correctly
 
 ### Security
 

--- a/plugins/dg/commands/launch.md
+++ b/plugins/dg/commands/launch.md
@@ -24,7 +24,7 @@ The `dg launch` command is the modern, streamlined way to materialize assets in 
 dg launch --assets my_asset
 
 # Multiple specific assets
-dg launch --assets asset_1 asset_2 asset_3
+dg launch --assets asset_1,asset_2,asset_3
 
 # All assets
 dg launch --assets "*"
@@ -61,7 +61,7 @@ The `--assets` flag accepts powerful selection patterns to target specific asset
 dg launch --assets customers
 
 # Multiple assets by name
-dg launch --assets customers orders products
+dg launch --assets customers,orders,products
 
 # Wildcard patterns
 dg launch --assets "customer*"        # All assets starting with "customer"
@@ -780,7 +780,7 @@ Migrating from legacy `dagster asset materialize` to modern `dg launch`.
 |----------------|-------------------|
 | `dagster asset materialize -a my_asset` | `dg launch --assets my_asset` |
 | `dagster asset materialize --select my_asset` | `dg launch --assets my_asset` |
-| `dagster asset materialize -a asset1 -a asset2` | `dg launch --assets asset1 asset2` |
+| `dagster asset materialize -a asset1 -a asset2` | `dg launch --assets asset1,asset2` |
 | `python -m dagster asset materialize -a my_asset` | `dg launch --assets my_asset` or `uv run dg launch --assets my_asset` |
 | `dagster asset materialize --select "tag:priority=high"` | `dg launch --assets "tag:priority=high"` |
 | `dagster job execute -j my_job` | `dg launch --job my_job` |
@@ -812,7 +812,7 @@ All legacy features are supported in `dg launch`:
 | Feature | Legacy | Modern |
 |---------|--------|--------|
 | Single asset | `-a my_asset` | `--assets my_asset` |
-| Multiple assets | `-a a1 -a a2` | `--assets a1 a2` |
+| Multiple assets | `-a a1 -a a2` | `--assets a1,a2` |
 | Selection patterns | `--select "tag:x"` | `--assets "tag:x"` |
 | Partitions | `--partition` | `--partition` |
 | Partition ranges | `--partition-range` | `--partition-range` |

--- a/plugins/dg/skills/launch/SKILL.md
+++ b/plugins/dg/skills/launch/SKILL.md
@@ -94,7 +94,7 @@ User: "Run my sales pipeline assets"
 → Based on response, provide appropriate command:
   dg launch --assets "group:sales_analytics"
   # or
-  dg launch --assets customers orders revenue
+  dg launch --assets customers,orders,revenue
 ```
 
 ### Partition Launch
@@ -247,7 +247,7 @@ dg launch --assets "group:analytics"
 dg launch --assets "kind:dbt"
 
 # Specific (good for ad-hoc)
-dg launch --assets customers orders
+dg launch --assets customers,orders
 
 # Wildcard (good for namespaces)
 dg launch --assets "staging_*"


### PR DESCRIPTION
## Summary & Motivation

Resolves #17

Corrects the /dg:launch skill documentation to use comma-separated syntax for multiple assets (--assets asset1,asset2,asset3) instead of the incorrect space-separated format (--assets asset1 asset2 asset3). The fix was verified against the actual Dagster CLI implementation which explicitly uses .split(",") to parse asset names. Selection patterns using tags, groups, and kinds (which use different syntax within quotes) are preserved correctly. This ensures Claude generates syntactically valid dg launch commands when users invoke the skill.

## How I Tested These Changes

## Changelog

> Insert changelog entry or delete this section.
