### PR TITLE
Fix marketplace reference in plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install using the
 ```
 /plugin marketplace add dagster-io/skills
 
-/plugin install dagster-expert@dagster-skills
+/plugin install dagster-expert@dagster
 
 /dagster-expert "What's an asset?"
 ```


### PR DESCRIPTION
## Summary & Motivation

When I tried to install the plugin within Claude Code, using the commands in the readme, I got an error:

<img width="501" height="140" alt="image" src="https://github.com/user-attachments/assets/d84c159f-dfdf-41b0-80b8-52169b05b158" />

It seems that the only change is to use the marketplace added in the previous step, i.e. `/plugin install dagster-expert@dagster`.

I would like to fix this so that other users get a smooth installation experience when trying out these skills!

## Test Plan

1. Open a Claude Code session where the skills are not yet installed
1. Run the command in the proposed Readme edit `/plugin install dagster-expert@dagster`
1. Reload plugins with `/reload-plugins`
1. Test the command in the readme, `/dagster-expert:dagster-expert what's an asset?`
 
Here's an example output from a personal project I've been working on:

<img width="1005" height="406" alt="image" src="https://github.com/user-attachments/assets/89cdd8ff-cb4f-4408-b0db-49272847f8f5" />



